### PR TITLE
add fedora and solr url defaults

### DIFF
--- a/roles/hyrax/tasks/main.yml
+++ b/roles/hyrax/tasks/main.yml
@@ -377,17 +377,9 @@
     mode: u=rw,g=r,o=r
 
 - name: Configure initial collection types and workflows
-  command: "/usr/local/bin/bundle exec rails hyrax:default_collection_types:create hyrax:default_admin_set:create hyrax:workflow:load"
+  command: "bash -l -c 'bundle exec rails hyrax:default_collection_types:create hyrax:default_admin_set:create hyrax:workflow:load'"
   args:
     chdir: "{{ ansistrano_deploy_to }}/current"
   become: yes
   become_user: hyrax
   changed_when: False
-  environment:
-    SECRET_KEY_BASE: "{{ hyrax_secret_key_base }}"
-    HYRAX_POSTGRESQL_PASSWORD: "{{ hyrax_postgresqldatabase_user_password }}"
-    RAILS_ENV: production
-  
-
-
-  

--- a/roles/hyrax/templates/dotenv
+++ b/roles/hyrax/templates/dotenv
@@ -1,7 +1,9 @@
-SECRET_KEY_BASE={{ hyrax_secret_key_base }}
+FEDORA_URL=http://localhost:8080/fcrepo/rest
 HYRAX_POSTGRESQL_PASSWORD={{ hyrax_postgresqldatabase_user_password }}
 RAILS_ENV=production
-SETTINGS__MULTITENANCY__ENABLED=false
+SECRET_KEY_BASE={{ hyrax_secret_key_base }}
 SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER=sidekiq
 SETTINGS__CONTACT_EMAIL={{ hyrax_from_email_address }}
 SETTINGS__DEVISE__INVITATION_FROM_EMAIL={{ hyrax_from_email_address }}
+SETTINGS__MULTITENANCY__ENABLED=false
+SOLR_URL=http://localhost:8983/solr/blacklight-core


### PR DESCRIPTION
Solr URL and Fedora URL needed to be added to the env so that works can be created successfully.  

Once big change in the setup as part of the ansistrano code was to make a .env file (/var/www/hyrax/.env) which keeps the various environment pieces.  That gets loaded by puma, sidekiq, and the hyrax user account meaning we don't have to specify env variables in every task. Especially useful now that there are more things that are required to get a rails console or rake task to run.

Ref #33 