### PR TITLE
SE Linux to allow Fedora to talk to Postgres

### DIFF
--- a/roles/fedora4/tasks/main.yml
+++ b/roles/fedora4/tasks/main.yml
@@ -73,6 +73,11 @@
   changed_when: false
   when: ansible_distribution == "CentOS"
 
+- name: Set setsebool tomcat_can_network_connect_db on
+  command: /usr/sbin/setsebool -P tomcat_can_network_connect_db on
+  changed_when: false
+  when: ansible_distribution == "CentOS"
+
 - name: Overwrite the Tomcat users file
   template:
     src: tomcat-users.xml


### PR DESCRIPTION
Though it looks like Fcrepo comes up in the current install, it is
never able to talk to Postgres on CentOS. Therefore nothing can be
written to Fcrepo.

This fix enables Tomcat apps to talk to the database with out
disabling selinux.

Fixes #33 